### PR TITLE
Ab#35 extend cicle ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,4 +26,5 @@ workflows:
     jobs:
       - maven/test:
           executor: java_c
+          command: -P circleci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - publish-docker
+      - build-test-publish-docker
 
 jobs:
-  publish-docker:
+  build-test-publish-docker:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
     working_directory: ~/repo
@@ -18,10 +18,12 @@ jobs:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
       - run: mvn dependency:go-offline
+      # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
       - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
       - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
       - run: chmod +x ./mvnw
       - run:
+          # Using Google Jib to build Docker image and publish it to Docker registry
           name: Build, unit test and install
           command: |
             ./mvnw install -B -P circleci \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,5 @@ workflows:
     jobs:
       - maven/test:
           executor: java_13
-          command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
+          command: -P circleci verify -Dmaven_security_master={rrNPVgq2hjgHiVuBjLfeCu2kdWSjh1/Ti19jBmWeFIBkeVLYgFbwQlunFAqpTctH6DqBdt7bKYeJpFsGpTuYV1DrFNo5APQvNHCjLLBTxVs=} --settings '.mvn/wrapper/settings.xml'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,21 +3,24 @@ version: 2.1
 # Use a package of configuration called an orb.
 orbs:
   # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.3.1
+  #welcome: circleci/welcome-orb@0.3.1
   maven: circleci/maven@0.0.11
 executors:
   java_14:
     docker:
       - image: circleci/openjdk:14-ea-jdk-buster-node-browsers-legacy
+  java_13:
+    docker:
+      - image: openjdk:13
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
-  welcome:
+  #welcome:
     # Run the welcome/run job in its own container
-    jobs:
-      - welcome/run
+    #jobs:
+      #- welcome/run
   maven:
     jobs:
       - maven/test:
-          executor: java_14
+          executor: java_13
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,5 +26,5 @@ workflows:
     jobs:
       - maven/test:
           executor: java_c
-          command: -P circleci
+          command: -P circleci test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,27 @@ workflows:
           command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
 
 jobs:
-    my-job:
-      executor: java_13
-      steps:
-        -shell: sh ./build_docker.sh
+  publish-docker:
+    docker:
+      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - hello-spring-mvn-V2-{{ checksum "pom.xml" }}
+            - hello-spring-mvn-V2
+      - run: mvn dependency:go-offline
+      - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+      - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+      - run:
+          name: Publish Docker image with Jib
+          command: |
+            ./mvnw compile jib:build -B -DskipTests=true \
+              -Dbuild.number=${CIRCLE_BUILD_NUM} \
+              -Dcommit.hash=${CIRCLE_SHA1} \
+              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: circleci/openjdk:14-ea-jdk-buster-node-browsers-legacy
   java_13:
     docker:
-      - image: openjdk:13
+      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
   java_c:
     docker:
       - image: circleci/openjdk
@@ -25,6 +25,6 @@ workflows:
   maven:
     jobs:
       - maven/test:
-          executor: java_c
-          command: -P circleci test
+          executor: java_13
+          command: -P circleci verify
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - run: mvn dependency:go-offline
       - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
       - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+      - run: chmod +x ./mvnw
       - run:
           name: Publish Docker image with Jib
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,29 +2,16 @@
 version: 2.1
 # Use a package of configuration called an orb.
 orbs:
-  # Declare a dependency on the welcome-orb
-  #welcome: circleci/welcome-orb@0.3.1
   maven: circleci/maven@0.0.11
 executors:
-  java_14:
-    docker:
-      - image: circleci/openjdk:14-ea-jdk-buster-node-browsers-legacy
   java_13:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
-  java_c:
-    docker:
-      - image: circleci/openjdk
 # Orchestrate or schedule a set of jobs
 workflows:
-  # Name the workflow "welcome"
-  #welcome:
-    # Run the welcome/run job in its own container
-    #jobs:
-      #- welcome/run
   maven:
     jobs:
       - maven/test:
           executor: java_13
-          command: -P circleci verify
+          command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
 jobs:
     my-job:
       executor: java_13
-      shell: sh ./build_docker.sh
+      steps:
+        shell: sh ./build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ workflows:
 jobs:
     my-job:
       executor: java_13
-      command: sh ./build_docker.sh
+      shell: sh ./build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Use a package of configuration called an orb.
 orbs:
   # Declare a dependency on the welcome-orb
-  #welcome: circleci/welcome-orb@0.3.1
+  welcome: circleci/welcome-orb@0.3.1
   maven: circleci/maven@0.0.11
 executors:
   java_14:
@@ -15,10 +15,10 @@ executors:
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
-  #welcome:
+  welcome:
     # Run the welcome/run job in its own container
-    #jobs:
-      #- welcome/run
+    jobs:
+      - welcome/run
   maven:
     jobs:
       - maven/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,41 +4,9 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - unit-test
       - publish-docker:
-          requires:
-            - unit-test
 
 jobs:
-  unit-test:
-    docker:
-      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - hello-spring-mvn-V2-{{ checksum "pom.xml" }}
-            - hello-spring-mvn-V2
-      - run: mvn dependency:go-offline
-      - run:
-          name: Build and unit test
-          command: |
-            mvn test -B \
-              -Dbuild.number=${CIRCLE_BUILD_NUM} \
-              -Dcommit.hash=${CIRCLE_SHA1} \
-              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME} 
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: hello-spring-mvn-V2-{{ checksum "pom.xml" }}
-      - store_test_results:
-          path: target/surefire-reports
-
-
-
   publish-docker:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
@@ -54,11 +22,18 @@ jobs:
       - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
       - run: chmod +x ./mvnw
       - run:
-          name: Publish Docker image with Jib
+          name: Build, unit test and install
           command: |
-            ./mvnw compile jib:build -B -DskipTests=true \
+            ./mvnw install -B \
               -Dbuild.number=${CIRCLE_BUILD_NUM} \
               -Dcommit.hash=${CIRCLE_SHA1} \
               -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
               -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
+              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME} 
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: hello-spring-mvn-V2-{{ checksum "pom.xml" }}
+      - store_test_results:
+          path: target/surefire-reports
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,11 @@ workflows:
       - maven/test:
           executor: java_13
           command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
-    steps:
-      -run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
-      -run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
-      -run: ./mvnw compile jib:build -B -DskipTests=true \
-        -Dbuild.number=${CIRCLE_BUILD_NUM} \
-        -Dcommit.hash=${CIRCLE_SHA1} \
-        -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-        -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-        -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
+
+jobs:
+    my-job:
+      executor: java_13
+      steps:
+        -run: sh build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Build, unit test and install
           command: |
-            ./mvnw install -B \
+            ./mvnw install -B -P circleci \
               -Dbuild.number=${CIRCLE_BUILD_NUM} \
               -Dcommit.hash=${CIRCLE_SHA1} \
               -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,6 @@ jobs:
     my-job:
       executor: java_13
       steps:
-        -run: sh build_docker.sh
+        -run: build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,44 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
-orbs:
-  maven: circleci/maven@0.0.11
-executors:
-  java_13:
-    docker:
-      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
-# Orchestrate or schedule a set of jobs
+
 workflows:
-  maven:
+  version: 2
+  build-deploy:
     jobs:
-      - maven/test:
-          executor: java_13
-          command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
+      - unit-test
+      - publish-docker:
+          requires:
+            - unit-test
 
 jobs:
+  unit-test:
+    docker:
+      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - hello-spring-mvn-V2-{{ checksum "pom.xml" }}
+            - hello-spring-mvn-V2
+      - run: mvn dependency:go-offline
+      - run:
+          name: Build and unit test
+          command: |
+            mvn test -B \
+              -Dbuild.number=${CIRCLE_BUILD_NUM} \
+              -Dcommit.hash=${CIRCLE_SHA1} \
+              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME} 
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: hello-spring-mvn-V2-{{ checksum "pom.xml" }}
+      - store_test_results:
+          path: target/surefire-reports
+
+
+
   publish-docker:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
@@ -38,5 +61,3 @@ jobs:
               -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
               -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
               -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ executors:
   java_13:
     docker:
       - image: openjdk:13
+  java_c:
+    docker:
+      - image: circleci/openjdk
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
@@ -22,5 +25,5 @@ workflows:
   maven:
     jobs:
       - maven/test:
-          executor: java_14
+          executor: java_c
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,6 @@ jobs:
     my-job:
       executor: java_13
       steps:
-        shell: sh ./build_docker.sh
+        -shell: sh ./build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ workflows:
 jobs:
     my-job:
       executor: java_13
-      steps:
-        -run: build_docker.sh
+      command: sh ./build_docker.sh
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - publish-docker:
+      - publish-docker
 
 jobs:
   publish-docker:
@@ -15,8 +15,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - hello-spring-mvn-V2-{{ checksum "pom.xml" }}
-            - hello-spring-mvn-V2
+            - bookit-event-{{ checksum "pom.xml" }}
+            - bookit-event
       - run: mvn dependency:go-offline
       - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
       - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
@@ -33,7 +33,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: hello-spring-mvn-V2-{{ checksum "pom.xml" }}
+          key: bookit-event-{{ checksum "pom.xml" }}
       - store_test_results:
           path: target/surefire-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ version: 2.1
 orbs:
   # Declare a dependency on the welcome-orb
   welcome: circleci/welcome-orb@0.3.1
+  maven: circleci/maven@0.0.11
+executors:
+  java_14:
+    docker:
+      - image: circleci/openjdk:14-ea-jdk-buster-node-browsers-legacy
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
@@ -11,3 +16,8 @@ workflows:
     # Run the welcome/run job in its own container
     jobs:
       - welcome/run
+  maven:
+    jobs:
+      - maven/test:
+          executor: java_14
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Use a package of configuration called an orb.
 orbs:
   # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.3.1
+  #welcome: circleci/welcome-orb@0.3.1
   maven: circleci/maven@0.0.11
 executors:
   java_14:
@@ -15,10 +15,10 @@ executors:
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
-  welcome:
+  #welcome:
     # Run the welcome/run job in its own container
-    jobs:
-      - welcome/run
+    #jobs:
+      #- welcome/run
   maven:
     jobs:
       - maven/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,5 +22,5 @@ workflows:
   maven:
     jobs:
       - maven/test:
-          executor: java_13
+          executor: java_14
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,15 @@ workflows:
     jobs:
       - maven/test:
           executor: java_13
-          command: -P circleci verify -Dmaven_security_master={rrNPVgq2hjgHiVuBjLfeCu2kdWSjh1/Ti19jBmWeFIBkeVLYgFbwQlunFAqpTctH6DqBdt7bKYeJpFsGpTuYV1DrFNo5APQvNHCjLLBTxVs=} --settings '.mvn/wrapper/settings.xml'
+          command: -P circleci verify --settings '.mvn/wrapper/settings.xml'
+    steps:
+      -run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+      -run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+      -run: ./mvnw compile jib:build -B -DskipTests=true \
+        -Dbuild.number=${CIRCLE_BUILD_NUM} \
+        -Dcommit.hash=${CIRCLE_SHA1} \
+        -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+        -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+        -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
+
 

--- a/.mvn/wrapper/settings.xml
+++ b/.mvn/wrapper/settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>registry-1.docker.io</id>
+            <username>proteamk60</username>
+            <password>{L9Ek2S4IXr8HyQoDmE3dr1F/B6VtSbC1PJ05iNOaYC8=}</password>
+        </server>
+    </servers>
+</settings>

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
 echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
 ./mvnw compile jib:build -B -DskipTests=true \

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
-echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
-./mvnw compile jib:build -B -DskipTests=true \
-              -Dbuild.number=${CIRCLE_BUILD_NUM} \
-              -Dcommit.hash=${CIRCLE_SHA1} \
-              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,8 @@
+cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+./mvnw compile jib:build -B -DskipTests=true \
+              -Dbuild.number=${CIRCLE_BUILD_NUM} \
+              -Dcommit.hash=${CIRCLE_SHA1} \
+              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 		<spring-cloud-sleuth.version>2.1.0.RELEASE</spring-cloud-sleuth.version>
 		<tomcat.port>8080</tomcat.port>
+		<build.number>000</build.number>
+		<commit.hash>local-build</commit.hash>
+		<build.user>local-build</build.user>
+		<build.repo>local-build</build.repo>
+		<circle.workflow.guid>local-build</circle.workflow.guid>
 	</properties>
 
 	<dependencies>
@@ -93,6 +98,7 @@
 			<id>circleci</id>
 			<build>
 				<plugins>
+					<!--
 					<plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
@@ -104,6 +110,7 @@
                             </execution>
                         </executions>
                     </plugin>
+                    -->
                     <plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
@@ -157,6 +164,41 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>1.7.0</version>
+                <configuration>
+					<from>
+						<image>registry://docker.io/proteamk60/aml-eventjdk:0.0.1-SNAPSHOT</image>
+					</from>
+                    <to>
+                        <image>docker.io/proteamk60/${project.artifactId}:${project.version}-b${build.number}</image>
+                    </to>
+					<container>
+						<jvmFlags>
+							<jvmFlag>-Dbuild.number=${build.number}</jvmFlag>
+							<jvmFlag>-Dcommit.hash=${commit.hash}</jvmFlag>
+							<jvmFlag>-Dbuild.user=${build.user}</jvmFlag>
+							<jvmFlag>-Dbuild.repo=${build.repo}</jvmFlag>
+							<jvmFlag>-Dcircle.workflow.guid=${circle.workflow.guid}</jvmFlag>
+						</jvmFlags>
+						<ports>
+							<port>${tomcat.port}</port>
+						</ports>
+						<workingDirectory>/app</workingDirectory>
+					</container>
+                </configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>build</goal>
+						</goals>
+					</execution>
+				</executions>
+            </plugin>
+			<!--
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>dockerfile-maven-plugin</artifactId>
@@ -178,6 +220,7 @@
 					</buildArgs>
 				</configuration>
 			</plugin>
+			-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>13</source>
-					<target>13</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,17 @@
 			<build>
 				<plugins>
 					<plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>${dockerfile-maven-version}</version>
+                        <executions>
+                            <execution>
+                                <id>default-spotify</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
 						<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -100,20 +100,9 @@
 						<executions>
 							<execution>
 								<id>default-spotify</id>
-								<goals>
-									<goal>build</goal>
-									<goal>push</goal>
-								</goals>
 								<phase>none</phase>
 							</execution>
 						</executions>
-						<configuration>
-							<repository>${project.artifactId}</repository>
-							<tag>${project.version}</tag>
-							<buildArgs>
-								<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-							</buildArgs>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
@@ -122,14 +111,6 @@
 							<execution>
 								<id>add-test-source</id>
 								<phase>none</phase>
-								<goals>
-									<goal>add-test-source</goal>
-								</goals>
-								<configuration>
-									<sources>
-										<source>src/it/java</source>
-									</sources>
-								</configuration>
 							</execution>
 						</executions>
 					</plugin>
@@ -139,10 +120,6 @@
 						<executions>
 							<execution>
 								<id>failsafe-execution</id>
-								<goals>
-									<goal>integration-test</goal>
-									<goal>verify</goal>
-								</goals>
 								<phase>none</phase>
 							</execution>
 						</executions>
@@ -155,35 +132,10 @@
 							<execution>
 								<id>prepare-it-bookit</id>
 								<phase>none</phase>
-								<goals>
-									<goal>start</goal>
-								</goals>
-								<configuration>
-									<images>
-										<image>
-											<name>bookit-event:0.0.1-SNAPSHOT</name>
-											<alias>bookit</alias>
-											<run>
-												<ports>
-													<port>tomcat.port:8080</port>
-												</ports>
-												<wait>
-													<http>
-														<url>http://localhost:${tomcat.port}/api/v1/events</url>
-													</http>
-													<time>10000</time>
-												</wait>
-											</run>
-										</image>
-									</images>
-								</configuration>
 							</execution>
 							<execution>
 								<id>remove-bookit</id>
 								<phase>none</phase>
-								<goals>
-									<goal>stop</goal>
-								</goals>
 							</execution>
 						</executions>
 					</plugin>
@@ -204,7 +156,6 @@
 						</goals>
 					</execution>
 				</executions>
-
 			</plugin>
 			<plugin>
 				<groupId>com.spotify</groupId>
@@ -308,5 +259,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 </configuration>
 				<executions>
 					<execution>
-						<phase>package</phase>
+						<phase>install</phase>
 						<goals>
 							<goal>build</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>13</source>
+					<target>13</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,41 @@
 			<id>circleci</id>
 			<build>
 				<plugins>
-					<!--
+					<plugin>
+						<groupId>com.google.cloud.tools</groupId>
+						<artifactId>jib-maven-plugin</artifactId>
+						<version>1.7.0</version>
+						<configuration>
+							<from>
+								<image>registry://docker.io/proteamk60/aml-eventjdk:0.0.1-SNAPSHOT</image>
+							</from>
+							<to>
+								<image>docker.io/proteamk60/${project.artifactId}:${project.version}-b${build.number}</image>
+							</to>
+							<container>
+								<jvmFlags>
+									<jvmFlag>-Dbuild.number=${build.number}</jvmFlag>
+									<jvmFlag>-Dcommit.hash=${commit.hash}</jvmFlag>
+									<jvmFlag>-Dbuild.user=${build.user}</jvmFlag>
+									<jvmFlag>-Dbuild.repo=${build.repo}</jvmFlag>
+									<jvmFlag>-Dcircle.workflow.guid=${circle.workflow.guid}</jvmFlag>
+								</jvmFlags>
+								<ports>
+									<port>${tomcat.port}</port>
+								</ports>
+								<workingDirectory>/app</workingDirectory>
+							</container>
+						</configuration>
+						<executions>
+							<execution>
+								<id>default-jib</id>
+								<phase>install</phase>
+								<goals>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
@@ -110,7 +144,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    -->
                     <plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
@@ -168,37 +201,13 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>1.7.0</version>
-                <configuration>
-					<from>
-						<image>registry://docker.io/proteamk60/aml-eventjdk:0.0.1-SNAPSHOT</image>
-					</from>
-                    <to>
-                        <image>docker.io/proteamk60/${project.artifactId}:${project.version}-b${build.number}</image>
-                    </to>
-					<container>
-						<jvmFlags>
-							<jvmFlag>-Dbuild.number=${build.number}</jvmFlag>
-							<jvmFlag>-Dcommit.hash=${commit.hash}</jvmFlag>
-							<jvmFlag>-Dbuild.user=${build.user}</jvmFlag>
-							<jvmFlag>-Dbuild.repo=${build.repo}</jvmFlag>
-							<jvmFlag>-Dcircle.workflow.guid=${circle.workflow.guid}</jvmFlag>
-						</jvmFlags>
-						<ports>
-							<port>${tomcat.port}</port>
-						</ports>
-						<workingDirectory>/app</workingDirectory>
-					</container>
-                </configuration>
 				<executions>
 					<execution>
-						<phase>install</phase>
-						<goals>
-							<goal>build</goal>
-						</goals>
+						<id>default-jib</id>
+						<phase>none</phase>
 					</execution>
 				</executions>
             </plugin>
-			<!--
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>dockerfile-maven-plugin</artifactId>
@@ -220,7 +229,6 @@
 					</buildArgs>
 				</configuration>
 			</plugin>
-			-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,17 +94,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>com.spotify</groupId>
-						<artifactId>dockerfile-maven-plugin</artifactId>
-						<version>${dockerfile-maven-version}</version>
-						<executions>
-							<execution>
-								<id>default-spotify</id>
-								<phase>none</phase>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
 						<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,109 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+	<profiles>
+		<profile>
+			<id>circleci</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.spotify</groupId>
+						<artifactId>dockerfile-maven-plugin</artifactId>
+						<version>${dockerfile-maven-version}</version>
+						<executions>
+							<execution>
+								<id>default-spotify</id>
+								<goals>
+									<goal>build</goal>
+									<goal>push</goal>
+								</goals>
+								<phase>none</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<repository>${project.artifactId}</repository>
+							<tag>${project.version}</tag>
+							<buildArgs>
+								<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+							</buildArgs>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>build-helper-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>add-test-source</id>
+								<phase>none</phase>
+								<goals>
+									<goal>add-test-source</goal>
+								</goals>
+								<configuration>
+									<sources>
+										<source>src/it/java</source>
+									</sources>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>failsafe-execution</id>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+								<phase>none</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>io.fabric8</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.20.1</version>
+						<executions>
+							<execution>
+								<id>prepare-it-bookit</id>
+								<phase>none</phase>
+								<goals>
+									<goal>start</goal>
+								</goals>
+								<configuration>
+									<images>
+										<image>
+											<name>bookit-event:0.0.1-SNAPSHOT</name>
+											<alias>bookit</alias>
+											<run>
+												<ports>
+													<port>tomcat.port:8080</port>
+												</ports>
+												<wait>
+													<http>
+														<url>http://localhost:${tomcat.port}/api/v1/events</url>
+													</http>
+													<time>10000</time>
+												</wait>
+											</run>
+										</image>
+									</images>
+								</configuration>
+							</execution>
+							<execution>
+								<id>remove-bookit</id>
+								<phase>none</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<build>
 		<plugins>
 			<plugin>
@@ -110,7 +212,7 @@
 				<version>${dockerfile-maven-version}</version>
 				<executions>
 					<execution>
-						<id>default</id>
+						<id>default-spotify</id>
 						<goals>
 							<goal>build</goal>
 							<goal>push</goal>
@@ -156,6 +258,7 @@
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>
+						<id>failsafe-execution</id>
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>


### PR DESCRIPTION
When maven runs with circleci profile it builds a docker image and publish it to proteamk60/bookit-event:${VERSION}-${CircleCI_BUILD_NUMBER}. 
If maven run without that profile, docket is built by spotifys plugin and integration tested with help from fabric8 plugin