### PR TITLE
Ab#51 add openapi spec generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,15 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build-test-publish-docker
+      - build-test
+      - publish-docker
+        requires: build-test
+        filters:
+          branches:
+            only: development
 
 jobs:
-  build-test-publish-docker:
+  build-test:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
     working_directory: ~/repo
@@ -18,24 +23,49 @@ jobs:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
       - run: mvn dependency:go-offline
-      # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
-      - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
-      - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
       - run: chmod +x ./mvnw
       - run:
-          # Using Google Jib to build Docker image and publish it to Docker registry
-          name: Build, unit test and install
+          # Plain maven build and test
+          name: Build and test
           command: |
-            ./mvnw install -B -P circleci \
-              -Dbuild.number=${CIRCLE_BUILD_NUM} \
-              -Dcommit.hash=${CIRCLE_SHA1} \
-              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME} 
+            ./mvnw verify -B -P circleci
       - save_cache:
           paths:
             - ~/.m2
           key: bookit-event-{{ checksum "pom.xml" }}
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - .mvn
+            - ./mvnw
+            - src
+            - target
       - store_test_results:
           path: target/surefire-reports
 
+  publish-docker:
+    docker:
+      - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
+      working_directory: ~/repo
+      steps:
+        - restore_cache:
+            keys:
+              - bookit-event-{{ checksum "pom.xml" }}
+              - bookit-event
+        -attach-workspace:
+          at: ~/repo
+          - run: mvn dependency:go-offline
+          # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
+          - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+          - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+          - run: chmod +x ./mvnw
+          - run:
+              # Using Google Jib to build Docker image and publish it to Docker registry
+              name: Build and test
+              command: |
+                ./mvnw jib:build -B -P circleci \
+                  -Dbuild.number=${CIRCLE_BUILD_NUM} \
+                  -Dcommit.hash=${CIRCLE_SHA1} \
+                  -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+                  -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+                  -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ workflows:
       - publish-docker:
           requires:
             - build-test
-        filters:
-          branches:
-            only: development
+          filters:
+            branches:
+              only: development
 
 jobs:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,19 +54,19 @@ jobs:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
       - attach_workspace:
-        at: ~/repo
-              - run: mvn dependency:go-offline
-          # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
-              - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
-              - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
-              - run: chmod +x ./mvnw
-              - run:
-                  # Using Google Jib to build Docker image and publish it to Docker registry
-                  name: Build and test
-                  command: |
-                ./mvnw jib:build -B -P circleci \
-                  -Dbuild.number=${CIRCLE_BUILD_NUM} \
-                  -Dcommit.hash=${CIRCLE_SHA1} \
-                  -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-                  -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-                  -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
+          at: ~/repo
+      - run: mvn dependency:go-offline
+      # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
+      - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+      - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+      - run: chmod +x ./mvnw
+      - run:
+          # Using Google Jib to build Docker image and publish it to Docker registry
+          name: Build and test
+          command: |
+        ./mvnw jib:build -B -P circleci \
+          -Dbuild.number=${CIRCLE_BUILD_NUM} \
+          -Dcommit.hash=${CIRCLE_SHA1} \
+          -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+          -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+          -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           keys:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
-      -attach_workspace:
+      - attach_workspace:
         at: ~/repo
               - run: mvn dependency:go-offline
           # Ensure it is possible to publish to ProTeamK60's repo on Docker hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,9 @@ workflows:
   build-deploy:
     jobs:
       - build-test
-      - publish-docker
-        requires:
-          - build-test
+      - publish-docker:
+          requires:
+            - build-test
         filters:
           branches:
             only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,9 @@ jobs:
           # Using Google Jib to build Docker image and publish it to Docker registry
           name: Build and test
           command: |
-        ./mvnw jib:build -B -P circleci \
-          -Dbuild.number=${CIRCLE_BUILD_NUM} \
-          -Dcommit.hash=${CIRCLE_SHA1} \
-          -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
-          -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
-          -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}
+            ./mvnw jib:build -B -P circleci \
+              -Dbuild.number=${CIRCLE_BUILD_NUM} \
+              -Dcommit.hash=${CIRCLE_SHA1} \
+              -Dcircle.workflow.guid=${CIRCLE_WORKFLOW_ID} \
+              -Dbuild.user=${CIRCLE_PROJECT_USERNAME} \
+              -Dbuild.repo=${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,14 @@ jobs:
   publish-docker:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
-      working_directory: ~/repo
-      steps:
-        - restore_cache:
-            keys:
-              - bookit-event-{{ checksum "pom.xml" }}
-              - bookit-event
-        -attach-workspace:
-          at: ~/repo
+    working_directory: ~/repo
+    steps:
+      - restore_cache:
+          keys:
+            - bookit-event-{{ checksum "pom.xml" }}
+            - bookit-event
+      -attach-workspace:
+        at: ~/repo
           - run: mvn dependency:go-offline
           # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
           - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ workflows:
     jobs:
       - build-test
       - publish-docker
-        requires: build-test
+        requires:
+          - build-test
         filters:
           branches:
             only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,17 +53,17 @@ jobs:
           keys:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
-      -attach-workspace:
+      -attach_workspace:
         at: ~/repo
-          - run: mvn dependency:go-offline
+              - run: mvn dependency:go-offline
           # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
-          - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
-          - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
-          - run: chmod +x ./mvnw
-          - run:
-              # Using Google Jib to build Docker image and publish it to Docker registry
-              name: Build and test
-              command: |
+              - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml
+              - run: echo "<settingsSecurity><master>${maven_security_master}</master></settingsSecurity>" > ~/.m2/settings-security.xml
+              - run: chmod +x ./mvnw
+              - run:
+                  # Using Google Jib to build Docker image and publish it to Docker registry
+                  name: Build and test
+                  command: |
                 ./mvnw jib:build -B -P circleci \
                   -Dbuild.number=${CIRCLE_BUILD_NUM} \
                   -Dcommit.hash=${CIRCLE_SHA1} \

--- a/pom.xml
+++ b/pom.xml
@@ -124,15 +124,6 @@
                                 <workingDirectory>/app</workingDirectory>
                             </container>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>default-jib</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>com.spotify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-core</artifactId>
+            <version>1.1.44</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.profiles.active=map
 management.endpoints.web.exposure.include=info,health,env,metrics
 logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG
 spring.application.name=bookit-event
+springdoc.api-docs.path=/api-docs/


### PR DESCRIPTION
Changed how CircleCI build and test the code and creat and push docker image to Docker Hub. Should only generated Docker image when changes occur in development branch