### PR TITLE
Restore workspace before restore cache so pom is available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
+            - pom.xml
             - .mvn
             - ./mvnw
             - src
@@ -49,12 +50,12 @@ jobs:
       - image: circleci/openjdk:13.0.1-jdk-buster-node-browsers-legacy
     working_directory: ~/repo
     steps:
+      - attach_workspace:
+          at: ~/repo
       - restore_cache:
           keys:
             - bookit-event-{{ checksum "pom.xml" }}
             - bookit-event
-      - attach_workspace:
-          at: ~/repo
       - run: mvn dependency:go-offline
       # Ensure it is possible to publish to ProTeamK60's repo on Docker hub
       - run: cp .mvn/wrapper/settings.xml ~/.m2/settings.xml


### PR DESCRIPTION
Previous build failed on restore cache because no pom.xml was available