### PR TITLE
Consume events from kafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Should be changed to more lightweight base image later. openjdk:13 image is 490 MB.
-FROM openjdk:13
+FROM proteamk60/aml-eventjdk:0.0.2-SNAPSHOT
 
 ARG JAR_FILE
 COPY target/${JAR_FILE} /app.jar

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,6 @@
                         <id>default-spotify</id>
                         <goals>
                             <goal>build</goal>
-                            <goal>push</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -282,6 +281,13 @@
                             </sources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>get-local-ip</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>local-ip</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -314,6 +320,13 @@
                                     <name>bookit-event:0.0.1-SNAPSHOT</name>
                                     <alias>bookit</alias>
                                     <run>
+                                        <env>
+                                            <KAFKA_BOOTSTRAP>my.kafka.host:9092</KAFKA_BOOTSTRAP>
+                                        </env>
+                                        <extraHosts>
+                                            <!--suppress UnresolvedMavenProperty -->
+                                            <extraHost>my.kafka.host:${local.ip}</extraHost>
+                                        </extraHosts>
                                         <ports>
                                             <port>tomcat.port:8080</port>
                                         </ports>

--- a/src/it/java/se/knowit/bookitevent/kafka/producer/KafkaEventProducerServiceImplIT.java
+++ b/src/it/java/se/knowit/bookitevent/kafka/producer/KafkaEventProducerServiceImplIT.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(SpringExtension.class)
 @EmbeddedKafka(partitions = 1,
         topics = {KafkaEventProducerServiceImplIT.TOPIC_NAME},
-        brokerProperties = "listeners=PLAINTEXT://localhost:9092")
+        brokerProperties = "listeners=PLAINTEXT://localhost:9093")
 @SpringBootTest
 public class KafkaEventProducerServiceImplIT {
 

--- a/src/main/java/se/knowit/bookitevent/configuration/kafka/KafkaConsumerConfiguration.java
+++ b/src/main/java/se/knowit/bookitevent/configuration/kafka/KafkaConsumerConfiguration.java
@@ -1,0 +1,56 @@
+package se.knowit.bookitevent.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import se.knowit.bookitevent.dto.EventDTO;
+import se.knowit.bookitevent.kafka.consumer.EventConsumer;
+import se.knowit.bookitevent.service.EventService;
+import se.knowit.bookitevent.servicediscovery.DiscoveryService;
+import se.knowit.bookitevent.servicediscovery.DiscoveryServiceResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfiguration {
+
+    private final DiscoveryService discoveryService;
+
+    public KafkaConsumerConfiguration(final DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @Bean
+    public ConsumerFactory<String, EventDTO> consumerFactory() {
+        DiscoveryServiceResult result = discoveryService.discoverInstances("bookit", "kafka");
+        Map<String,Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, result.getAddresses());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "event-consumer");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new JsonDeserializer<>(EventDTO.class, false));
+    }
+
+    @Bean
+    @Autowired
+    public ConcurrentKafkaListenerContainerFactory<String,EventDTO> kafkaListenerContainerFactory(final ConsumerFactory<String, EventDTO> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String,EventDTO> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+
+    @Bean
+    @Autowired
+    public EventConsumer eventConsumer(EventService eventService) { return new EventConsumer(eventService); }
+
+}

--- a/src/main/java/se/knowit/bookitevent/controller/EventController.java
+++ b/src/main/java/se/knowit/bookitevent/controller/EventController.java
@@ -18,8 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static se.knowit.bookitevent.service.EventService.Outcome.CREATED;
-import static se.knowit.bookitevent.service.EventService.Outcome.UPDATED;
+import static se.knowit.bookitevent.service.EventService.Outcome.*;
 
 @RestController
 @RequestMapping(EventController.BASE_PATH)
@@ -76,7 +75,7 @@ public class EventController {
 
         if (result.getOutcome() == CREATED) {
             return generateEventCreatedResponse(result);
-        } else if (result.getOutcome() == UPDATED) {
+        } else if (result.getOutcome() == UPDATED || result.getOutcome() == NO_CHANGE) {
             return generateEventUpdateAcceptedResponse(result);
         } else {
             return generateResponseForBadCreateOrUpdateEventRequest(result);

--- a/src/main/java/se/knowit/bookitevent/kafka/consumer/EventConsumer.java
+++ b/src/main/java/se/knowit/bookitevent/kafka/consumer/EventConsumer.java
@@ -1,0 +1,38 @@
+package se.knowit.bookitevent.kafka.consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.PartitionOffset;
+import org.springframework.kafka.annotation.TopicPartition;
+import se.knowit.bookitevent.dto.EventDTO;
+import se.knowit.bookitevent.service.EventService;
+
+import java.lang.invoke.MethodHandles;
+
+public class EventConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final EventService eventService;
+    
+    public EventConsumer(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    @KafkaListener(id = "event-listener",
+            topics = {"events"},
+            groupId = "event-consumer",
+            containerFactory = "kafkaListenerContainerFactory",
+            topicPartitions = @TopicPartition(
+                    topic = "events",
+                    partitionOffsets = @PartitionOffset(
+                            partition = "0",
+                            initialOffset = "0"
+                    )
+            )
+    )
+    public void consumeMessage(EventDTO event) {
+        LOG.trace("Consume event {}", event);
+        eventService.createOrUpdate(event);
+    }
+
+}

--- a/src/main/java/se/knowit/bookitevent/repository/map/EventRepositoryMapImpl.java
+++ b/src/main/java/se/knowit/bookitevent/repository/map/EventRepositoryMapImpl.java
@@ -9,7 +9,10 @@ import se.knowit.bookitevent.model.Event;
 import se.knowit.bookitevent.model.EventValidator;
 import se.knowit.bookitevent.repository.EventRepository;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -37,9 +40,15 @@ public class EventRepositoryMapImpl implements EventRepository {
     public Event save(Event incomingEvent) {
         Event event = eventValidator.ensureEventIsValidOrThrowException(incomingEvent);
         assignRequiredIds(event);
-        persistEvent(event);
-        publish(event);
+        Event oldEvent = persistEvent(event);
+        if (eventsAreDifferent(event, oldEvent)) {
+            publish(event);
+        }
         return event;
+    }
+    
+    private boolean eventsAreDifferent(Event event, Event oldEvent) {
+        return !event.equals(oldEvent);
     }
     
     private void publish(Event event) {

--- a/src/main/java/se/knowit/bookitevent/service/EventService.java
+++ b/src/main/java/se/knowit/bookitevent/service/EventService.java
@@ -16,7 +16,7 @@ public interface EventService {
     
     Optional<Event> findByEventId(UUID id);
     
-    enum Outcome {CREATED, UPDATED, FAILED}
+    enum Outcome {CREATED, UPDATED, FAILED, NO_CHANGE}
     
     class CreateOrUpdateCommandResult {
         private final Outcome outcome;

--- a/src/main/java/se/knowit/bookitevent/service/EventServiceImpl.java
+++ b/src/main/java/se/knowit/bookitevent/service/EventServiceImpl.java
@@ -28,6 +28,9 @@ public class EventServiceImpl implements EventService {
     @Override
     public CreateOrUpdateCommandResult createOrUpdate(EventDTO eventDTO) {
         Event event = mapper.fromDTO(eventDTO);
+        if (event.getEventId() != null && alreadyPresent(event)){
+            return new CreateOrUpdateCommandResult(Outcome.NO_CHANGE, event.getEventId());
+        }
         Outcome outcome = event.getEventId() == null ? CREATED: UPDATED;
         
         try {
@@ -36,6 +39,12 @@ public class EventServiceImpl implements EventService {
         } catch (RuntimeException e) {
             return new CreateOrUpdateCommandResult(e);
         }
+    }
+    
+    private boolean alreadyPresent(final Event event) {
+        Optional<Event> foundEvent = findByEventId(event.getEventId());
+        Optional<Event> equalEvent = foundEvent.filter(e -> e.equals(event));
+        return equalEvent.isPresent();
     }
     
     @Override

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,2 +1,3 @@
 aws.discovery.region=us-east-2
 logging.level.org.springframework.web.servlet.DispatcherServlet=INFO
+logging.level.se.knowit.bookitevent.kafka.consumer.EventConsumer=ERROR

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.profiles.active=@activatedProperties@
 management.endpoints.web.exposure.include=info,health,env,metrics
 logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG
+logging.level.se.knowit.bookitevent.kafka.consumer.EventConsumer=TRACE
 spring.application.name=bookit-event
 springdoc.api-docs.path=/api-docs/
 kafka.bootstrapAddress=${KAFKA_BOOTSTRAP:localhost:9092}

--- a/src/test/java/se/knowit/bookitevent/repository/map/EventRepositoryMapImplTest.java
+++ b/src/test/java/se/knowit/bookitevent/repository/map/EventRepositoryMapImplTest.java
@@ -91,6 +91,15 @@ class EventRepositoryMapImplTest {
     }
     
     @Test
+    void savingAnAlreadyStoredEventWithoutChangesShouldNotPublishToKafka() {
+        Event event = getValidTestEvent();
+        event.setEventId(UUID.randomUUID());
+        container.put(event.getEventId(), event);
+        eventRepository.save(event);
+        verifyNoInteractions(kafkaProducerService);
+    }
+    
+    @Test
     void itShouldNotBePossibleToSaveANullObject() {
         assertThrows(NullPointerException.class, () -> eventRepository.save(null));
     }

--- a/src/test/resources/application-dev.properties
+++ b/src/test/resources/application-dev.properties
@@ -1,0 +1,1 @@
+discovery.service.kafka=${KAFKA_BOOTSTRAP:localhost:9093}


### PR DESCRIPTION
Added kafka consumer in bookit-event. 
Also worked on trying to solve problems with running integration tests.
Big problem with docker-container getting access to kafka broker in different network.
Had to add an environment variable KAFKA_BOOTSTRAP to the container and also provide an ip address for the host name in KAFKA_BOOTSTRAP (my.kafka.host). 
This is done by adding the ip address of the docker host to /etc/hosts in the container. 
Also needed to add port proxying on my windows machine so it forwards to the Ubuntu machine I use for Kafka broker 